### PR TITLE
add: check for available threads prior to submitting requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools.command import sdist
 
 setup (
     name = 'weblyzard_api',
-    version = '0.4.8.7',
+    version = '0.4.8.8',
     description= ' Web services for weblyzard',
     author = 'Heinz-Peter Lang and Albert Weichselbraun',
     author_email = 'lang@weblyzard.com',


### PR DESCRIPTION
* add `has_queued_threads` method that checks whether all threads are currently occupied
* `submit_documents`: check for available thread prior to submitting the request and wait for a specific time period if no threads are available.