### PR TITLE
add: implemente the Comparator interface for MD5digest.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.weblyzard.api</groupId>
 	<artifactId>weblyzard-api</artifactId>
-	<version>0.0.14-SNAPSHOT</version>
+	<version>0.0.15-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>com.weblyzard.api.weblyzard-api</name>

--- a/src/java/main/com/weblyzard/api/datatype/MD5Digest.java
+++ b/src/java/main/com/weblyzard/api/datatype/MD5Digest.java
@@ -1,103 +1,117 @@
 package com.weblyzard.api.datatype;
 
-import java.io.Serializable;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-
-import javax.xml.bind.DatatypeConverter;
-import javax.xml.bind.annotation.adapters.XmlAdapter;
-
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.weblyzard.api.document.serialize.json.MD5DigestDeserializer;
 import com.weblyzard.api.document.serialize.json.MD5DigestSerializer;
+import java.io.Serializable;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Comparator;
+import javax.xml.bind.DatatypeConverter;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
 
 /**
  * A performance and memory optimized representation of MD5Digests.
- * @author albert.weichselbraun@htwchur.ch
  *
+ * @author albert.weichselbraun@htwchur.ch
  */
-
 @JsonSerialize(using = MD5DigestSerializer.class)
-@JsonDeserialize (using = MD5DigestDeserializer.class)
-public class MD5Digest extends XmlAdapter<String, MD5Digest> implements Serializable{
+@JsonDeserialize(using = MD5DigestDeserializer.class)
+public class MD5Digest extends XmlAdapter<String, MD5Digest>
+        implements Serializable, Comparator<MD5Digest> {
 
-	
-	private static final long serialVersionUID = 1L;
-	
-	private long low, high;
-	
-	public MD5Digest(byte[] m) {
-		high = fromBytes(m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7]);
-		low= fromBytes(m[8],m[9], m[10],m[11],m[12],m[13],m[14],m[15]);
-	}
-	
-	public MD5Digest() {}
-	
-	public static MD5Digest fromHexDigest(String hexString) {
-		byte[] messageDigest = DatatypeConverter.parseHexBinary(hexString);
-		return new MD5Digest(messageDigest);
-	}
-	
-	public static MD5Digest fromText(String text) {
-		return new MD5Digest(getMessageDigest().digest(text.getBytes()));
-	}
-	
-	@Override
-	public int hashCode() {
-		return (int)(low^(low>>>32)^high^(high>>>32));
-	}
-	
-	@Override
-	public boolean equals(Object o) {
-		try {
-			MD5Digest m = (MD5Digest) o;
-			return low == m.low && high == m.high;
-		} catch (ClassCastException | NullPointerException e) {
-			return false;
-		}
-	}
-	
-	@Override
-	public String toString() {
-		return String.format("%016X%016X", high, low).toLowerCase();
-	}
-	
-	public static MessageDigest getMessageDigest()  {
-		try {
-			return MessageDigest.getInstance("MD5");
-		} catch (NoSuchAlgorithmException e) {
-			// MD5 is supported according to the JVM specification
-			// this case can never happen...
-			throw new RuntimeException("The MD5 message digest is not supported by the JVM.");
-		}
-	}
+    private static final long serialVersionUID = 1L;
 
-	@Override
-	public MD5Digest unmarshal(String v) throws Exception {
-		return (v == null || v == "") ? null : MD5Digest.fromHexDigest(v); 
-	}
+    private long low, high;
 
-	@Override
-	public String marshal(MD5Digest v) throws Exception {
-		return v == null ? "" : v.toString();
-	}
-	
-	/*
-	 * 	The {@code long} value of the given big-endian representation of a long.
-	 *  
-	 * 	This code has been taken from
-	 *    https://github.com/google/guava/blob/master/guava/src/com/google/common/primitives/Longs.java
-	 */
-	private static long fromBytes(byte b1, byte b2, byte b3, byte b4, byte b5, byte b6, byte b7, byte b8) {
-	    return (b1 & 0xFFL) << 56
-	            | (b2 & 0xFFL) << 48
-	            | (b3 & 0xFFL) << 40
-	            | (b4 & 0xFFL) << 32
-	            | (b5 & 0xFFL) << 24
-	            | (b6 & 0xFFL) << 16
-	            | (b7 & 0xFFL) << 8
-	            | (b8 & 0xFFL);
-	}
-	
+    public MD5Digest(byte[] m) {
+        high = fromBytes(m[0], m[1], m[2], m[3], m[4], m[5], m[6], m[7]);
+        low = fromBytes(m[8], m[9], m[10], m[11], m[12], m[13], m[14], m[15]);
+    }
+
+    public MD5Digest() {}
+
+    public static MD5Digest fromHexDigest(String hexString) {
+        byte[] messageDigest = DatatypeConverter.parseHexBinary(hexString);
+        return new MD5Digest(messageDigest);
+    }
+
+    public static MD5Digest fromText(String text) {
+        return new MD5Digest(getMessageDigest().digest(text.getBytes()));
+    }
+
+    @Override
+    public int hashCode() {
+        return (int) (low ^ (low >>> 32) ^ high ^ (high >>> 32));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        try {
+            MD5Digest m = (MD5Digest) o;
+            return low == m.low && high == m.high;
+        } catch (ClassCastException | NullPointerException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%016X%016X", high, low).toLowerCase();
+    }
+
+    public static MessageDigest getMessageDigest() {
+        try {
+            return MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            // MD5 is supported according to the JVM specification
+            // this case can never happen...
+            throw new RuntimeException("The MD5 message digest is not supported by the JVM.");
+        }
+    }
+
+    @Override
+    public MD5Digest unmarshal(String v) throws Exception {
+        return (v == null || v == "") ? null : MD5Digest.fromHexDigest(v);
+    }
+
+    @Override
+    public String marshal(MD5Digest v) throws Exception {
+        return v == null ? "" : v.toString();
+    }
+
+    /*
+     * 	The {@code long} value of the given big-endian representation of a long.
+     *
+     * 	This code has been taken from
+     *    https://github.com/google/guava/blob/master/guava/src/com/google/common/primitives/Longs.java
+     */
+    private static long fromBytes(
+            byte b1, byte b2, byte b3, byte b4, byte b5, byte b6, byte b7, byte b8) {
+        return (b1 & 0xFFL) << 56
+                | (b2 & 0xFFL) << 48
+                | (b3 & 0xFFL) << 40
+                | (b4 & 0xFFL) << 32
+                | (b5 & 0xFFL) << 24
+                | (b6 & 0xFFL) << 16
+                | (b7 & 0xFFL) << 8
+                | (b8 & 0xFFL);
+    }
+
+    @Override
+    public int compare(MD5Digest d1, MD5Digest d2) {
+        if (d1.high > d2.high) {
+            return 1;
+        } else if (d1.high < d2.high) {
+            return -1;
+        }
+
+        if (d1.low > d2.low) {
+            return 1;
+        } else if (d1.low < d2.low) {
+            return -1;
+        }
+        return 0;
+    }
 }

--- a/src/java/main/com/weblyzard/api/datatype/MD5Digest.java
+++ b/src/java/main/com/weblyzard/api/datatype/MD5Digest.java
@@ -19,7 +19,7 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 @JsonSerialize(using = MD5DigestSerializer.class)
 @JsonDeserialize(using = MD5DigestDeserializer.class)
 public class MD5Digest extends XmlAdapter<String, MD5Digest>
-        implements Serializable, Comparator<MD5Digest> {
+        implements Serializable, Comparator<MD5Digest>, Comparable<MD5Digest> {
 
     private static final long serialVersionUID = 1L;
 
@@ -113,5 +113,10 @@ public class MD5Digest extends XmlAdapter<String, MD5Digest>
             return -1;
         }
         return 0;
+    }
+
+    @Override
+    public int compareTo(MD5Digest o) {
+        return compare(this, o);
     }
 }

--- a/src/java/test/com/weblyzard/api/datatype/MD5DigestTest.java
+++ b/src/java/test/com/weblyzard/api/datatype/MD5DigestTest.java
@@ -3,7 +3,10 @@ package com.weblyzard.api.datatype;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.Test;
 
 public class MD5DigestTest {
@@ -24,14 +27,23 @@ public class MD5DigestTest {
         assertTrue(mid.compare(larger1, larger1) == 0);
         assertTrue(mid.compare(larger2, larger2) == 0);
 
-        // sorting
+        // sorting using Comparator
         List<MD5Digest> lst = Arrays.asList(larger2, mid, larger1);
         lst.sort(new MD5Digest());
+        assertNotEquals(Arrays.asList(larger2, mid, larger1), lst);
+        assertEquals(Arrays.asList(mid, larger1, larger2), lst);
+
+        // sorting using Comparable
+        lst =
+                Stream.of(larger2, mid, larger1)
+                        .sorted(Comparator.naturalOrder())
+                        .collect(Collectors.toList());
         assertNotEquals(Arrays.asList(larger2, mid, larger1), lst);
         assertEquals(Arrays.asList(mid, larger1, larger2), lst);
     }
 
     @Test
+    @SuppressWarnings("unlikely-arg-type")
     public void testEquals() {
         final MD5Digest mid = MD5Digest.fromHexDigest("38338baad6b2c8864e969803250d2391");
         final MD5Digest larger1 = MD5Digest.fromHexDigest("38338baad6b2c8864e969803250d2392");

--- a/src/java/test/com/weblyzard/api/datatype/MD5DigestTest.java
+++ b/src/java/test/com/weblyzard/api/datatype/MD5DigestTest.java
@@ -2,14 +2,94 @@ package com.weblyzard.api.datatype;
 
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.xml.bind.DatatypeConverter;
 import org.junit.Test;
 
 public class MD5DigestTest {
+
+    private final int SAMPLE_SIZE = 1000;
+
+    @Test
+    public void testFromHexDigest() {
+        final String text = "Ringstrasse 34, 7000 Chur";
+        MD5Digest m = MD5Digest.fromText(text);
+        MD5Digest mFromDigest = MD5Digest.fromHexDigest("34acdf2d3df92b5e360159f2f664a9e4");
+        assertEquals(m, mFromDigest);
+        assertEquals(m.toString(), mFromDigest.toString());
+    }
+
+    @Test
+    public void testFromText() {
+        final String text = "Ringstrasse 34, 7000 Chur";
+        MD5Digest m = MD5Digest.fromText(text);
+        String md5string =
+                DatatypeConverter.printHexBinary(
+                        MD5Digest.getMessageDigest().digest(text.getBytes()));
+        assertEquals(md5string.toLowerCase(), m.toString());
+    }
+
+    @Test
+    public void testEqualsObject() {
+        Random rnd = new Random();
+        // generate test data
+        System.out.println("Generating random testdata.");
+        List<String> testData = new ArrayList<>(SAMPLE_SIZE);
+        for (int i = 0; i < SAMPLE_SIZE; i++) {
+            testData.add("" + rnd.nextLong());
+        }
+        long time;
+
+        System.out.println("Comparing test data with Strings");
+        time = System.nanoTime();
+        List<String> digestString = new ArrayList<>(SAMPLE_SIZE);
+        for (int i = 0; i < SAMPLE_SIZE; i++) {
+            digestString.add(
+                    DatatypeConverter.printHexBinary(
+                                    MD5Digest.getMessageDigest().digest(testData.get(i).getBytes()))
+                            .toLowerCase());
+        }
+
+        for (int i = 0; i < SAMPLE_SIZE; i++) {
+            for (int j = 0; j < SAMPLE_SIZE; j++) {
+                if (testData.get(i) != testData.get(j)) {
+                    assertNotEquals(digestString.get(i), digestString.get(j));
+                } else {
+                    assertEquals(digestString.get(i), digestString.get(j));
+                }
+            }
+        }
+        System.out.println("Time Required " + (System.nanoTime() - time));
+
+        System.out.println("Comparing test data with MD5Digest");
+        time = System.nanoTime();
+        List<MD5Digest> digestData = new ArrayList<>(SAMPLE_SIZE);
+        for (int i = 0; i < SAMPLE_SIZE; i++) {
+            digestData.add(MD5Digest.fromText(testData.get(i)));
+        }
+        for (int i = 0; i < SAMPLE_SIZE; i++) {
+            for (int j = 0; j < SAMPLE_SIZE; j++) {
+                if (testData.get(i) != testData.get(j)) {
+                    assertNotEquals(digestData.get(i), digestData.get(j));
+                } else {
+                    assertEquals(digestData.get(i), digestData.get(j));
+                }
+            }
+        }
+        System.out.println("Time Required " + (System.nanoTime() - time));
+
+        // ensure that the string representation of the computed
+        // md5sums are identical
+        for (int i = 0; i < SAMPLE_SIZE; i++) {
+            assertEquals(digestData.get(i).toString(), digestString.get(i));
+        }
+    }
 
     @Test
     public void testCompare() {

--- a/src/java/test/com/weblyzard/api/datatype/MD5DigestTest.java
+++ b/src/java/test/com/weblyzard/api/datatype/MD5DigestTest.java
@@ -1,0 +1,47 @@
+package com.weblyzard.api.datatype;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class MD5DigestTest {
+
+    @Test
+    public void testCompare() {
+        final MD5Digest mid = MD5Digest.fromHexDigest("38338baad6b2c8864e969803250d2391");
+        final MD5Digest larger1 = MD5Digest.fromHexDigest("38338baad6b2c8864e969803250d2392");
+        final MD5Digest larger2 = MD5Digest.fromHexDigest("38338baad6b2c8874e969803250d2391");
+
+        // direct compare
+        assertTrue(mid.compare(mid, mid) == 0);
+        assertTrue(mid.compare(mid, larger1) == -1);
+        assertTrue(mid.compare(mid, larger2) == -1);
+        assertTrue(mid.compare(larger1, mid) == 1);
+        assertTrue(mid.compare(larger2, mid) == 1);
+
+        assertTrue(mid.compare(larger1, larger1) == 0);
+        assertTrue(mid.compare(larger2, larger2) == 0);
+
+        // sorting
+        List<MD5Digest> lst = Arrays.asList(larger2, mid, larger1);
+        lst.sort(new MD5Digest());
+        assertNotEquals(Arrays.asList(larger2, mid, larger1), lst);
+        assertEquals(Arrays.asList(mid, larger1, larger2), lst);
+    }
+
+    @Test
+    public void testEquals() {
+        final MD5Digest mid = MD5Digest.fromHexDigest("38338baad6b2c8864e969803250d2391");
+        final MD5Digest larger1 = MD5Digest.fromHexDigest("38338baad6b2c8864e969803250d2392");
+
+        // tests
+        assertTrue(mid.equals(mid));
+        assertTrue(larger1.equals(larger1));
+        assertFalse(mid.equals(larger1));
+
+        assertFalse(mid.equals(null));
+        assertFalse(mid.equals("test"));
+    }
+}

--- a/src/java/test/com/weblyzard/api/datatype/MD5DigestTest.java
+++ b/src/java/test/com/weblyzard/api/datatype/MD5DigestTest.java
@@ -48,9 +48,9 @@ public class MD5DigestTest {
         final MD5Digest mid = MD5Digest.fromHexDigest("38338baad6b2c8864e969803250d2391");
         final MD5Digest larger1 = MD5Digest.fromHexDigest("38338baad6b2c8864e969803250d2392");
 
-        // tests
-        assertTrue(mid.equals(mid));
-        assertTrue(larger1.equals(larger1));
+        // test equals
+        assertTrue(mid.equals(MD5Digest.fromHexDigest("38338baad6b2c8864e969803250d2391")));
+        assertTrue(larger1.equals(MD5Digest.fromHexDigest("38338baad6b2c8864e969803250d2392")));
         assertFalse(mid.equals(larger1));
 
         assertFalse(mid.equals(null));


### PR DESCRIPTION
Ground work for enabling a more efficient handling of annotations for NEK computations.
(adding comparator support to MD5digest).