### PR TITLE
Cleanup/document model class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.weblyzard.api</groupId>
 	<artifactId>weblyzard-api</artifactId>
-	<version>0.1.0.9-SNAPSHOT</version>
+	<version>0.1.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>com.weblyzard.api.weblyzard-api</name>

--- a/src/java/main/com/weblyzard/api/client/JeremiaClient.java
+++ b/src/java/main/com/weblyzard/api/client/JeremiaClient.java
@@ -1,12 +1,13 @@
 package com.weblyzard.api.client;
 
-import com.weblyzard.api.model.document.Document;
-import com.weblyzard.api.model.document.XmlDocument;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.xml.bind.JAXBException;
+import com.weblyzard.api.model.document.Document;
+import com.weblyzard.api.model.document.MirrorDocument;
+import com.weblyzard.api.model.document.XmlDocument;
 
 /** @author philipp.kuntschik@htwchur.ch */
 public class JeremiaClient extends BasicClient {
@@ -25,12 +26,10 @@ public class JeremiaClient extends BasicClient {
         super(weblyzardUrl, username, password);
     }
 
-    public XmlDocument submitDocumentRaw(Document data) throws WebApplicationException {
+    public XmlDocument submitDocumentRaw(MirrorDocument data) throws WebApplicationException {
 
-        Response response =
-                super.getTarget(SUBMIT_DOCUMENT_SERVICE_URL)
-                        .request(MediaType.APPLICATION_JSON_TYPE)
-                        .post(Entity.json(data));
+        Response response = super.getTarget(SUBMIT_DOCUMENT_SERVICE_URL)
+                .request(MediaType.APPLICATION_JSON_TYPE).post(Entity.json(data));
 
         super.checkResponseStatus(response);
         XmlDocument result = response.readEntity(XmlDocument.class);
@@ -39,8 +38,9 @@ public class JeremiaClient extends BasicClient {
         return result;
     }
 
-    public Document submitDocument(Document data) throws WebApplicationException, JAXBException {
+    public Document submitDocument(MirrorDocument data)
+            throws WebApplicationException, JAXBException {
         XmlDocument response = submitDocumentRaw(data);
-        return Document.unmarshallDocumentXmlString(response.getXmlContent());
+        return Document.fromXml(response.getXmlContent());
     }
 }

--- a/src/java/main/com/weblyzard/api/client/JesajaClient.java
+++ b/src/java/main/com/weblyzard/api/client/JesajaClient.java
@@ -59,7 +59,7 @@ public class JesajaClient extends BasicClient {
             throws WebApplicationException, JAXBException {
 
         List<String> xml = new ArrayList<>();
-        for (Document document : documents) xml.add(Document.getXmlRepresentation(document));
+        for (Document document : documents) xml.add(Document.toXml(document));
 
         Response response =
                 super.getTarget(ADD_DOCUMENTS_SERVICE_URL)
@@ -77,7 +77,7 @@ public class JesajaClient extends BasicClient {
             throws WebApplicationException, JAXBException {
 
         List<String> xml = new ArrayList<>();
-        for (Document document : documents) xml.add(Document.getXmlRepresentation(document));
+        for (Document document : documents) xml.add(Document.toXml(document));
 
         Response response =
                 super.getTarget(GET_KEYWORDS_SERVICE_URL)
@@ -97,7 +97,7 @@ public class JesajaClient extends BasicClient {
             throws WebApplicationException, JAXBException {
 
         List<String> xml = new ArrayList<>();
-        for (Document document : documents) xml.add(Document.getXmlRepresentation(document));
+        for (Document document : documents) xml.add(Document.toXml(document));
 
         Response response =
                 super.getTarget(GET_NEK_ANNOTATIONS_SERVICE_URL)

--- a/src/java/main/com/weblyzard/api/client/JoelClient.java
+++ b/src/java/main/com/weblyzard/api/client/JoelClient.java
@@ -1,7 +1,5 @@
 package com.weblyzard.api.client;
 
-import com.weblyzard.api.model.document.Document;
-import com.weblyzard.api.model.joel.ClusterResult;
 import java.util.Collections;
 import java.util.List;
 import javax.ws.rs.ClientErrorException;
@@ -11,6 +9,8 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.xml.bind.JAXBException;
+import com.weblyzard.api.model.document.Document;
+import com.weblyzard.api.model.joel.ClusterResult;
 
 /**
  * @author philipp.kuntschik@htwchur.ch
@@ -39,25 +39,21 @@ public class JoelClient extends BasicClient {
 
     public Response addDocuments(List<Document> documents)
             throws ClientErrorException, JAXBException {
-        Response response =
-                super.getTarget(ADDDOCUMENTS_SERVICE_URL)
-                        .request(MediaType.APPLICATION_JSON_TYPE)
-                        .post(Entity.json(documents));
+        Response response = super.getTarget(ADDDOCUMENTS_SERVICE_URL)
+                .request(MediaType.APPLICATION_JSON_TYPE).post(Entity.json(documents));
 
         super.checkResponseStatus(response);
         if (response.readEntity(String.class).equals(NO_KEYWORD_IN_DOCUMENT_HEADER_MESSAGE)) {
-            throw new ClientErrorException(
-                    NO_KEYWORD_IN_DOCUMENT_HEADER_MESSAGE, response.getStatus());
+            throw new ClientErrorException(NO_KEYWORD_IN_DOCUMENT_HEADER_MESSAGE,
+                    response.getStatus());
         }
         response.close();
         return response;
     }
 
     public Response flush() throws WebApplicationException {
-        Response response =
-                super.getTarget(FLUSH_DOCUMENT_SERVICE_URL)
-                        .request(MediaType.APPLICATION_JSON_TYPE)
-                        .get();
+        Response response = super.getTarget(FLUSH_DOCUMENT_SERVICE_URL)
+                .request(MediaType.APPLICATION_JSON_TYPE).get();
 
         super.checkResponseStatus(response);
         response.close();
@@ -65,10 +61,8 @@ public class JoelClient extends BasicClient {
     }
 
     public List<ClusterResult> cluster() throws WebApplicationException {
-        Response response =
-                super.getTarget(CLUSTER_DOCUMENT_SERVICEURL)
-                        .request(MediaType.APPLICATION_JSON_TYPE)
-                        .get();
+        Response response = super.getTarget(CLUSTER_DOCUMENT_SERVICEURL)
+                .request(MediaType.APPLICATION_JSON_TYPE).get();
 
         super.checkResponseStatus(response);
         List<ClusterResult> clusterResults =

--- a/src/java/main/com/weblyzard/api/model/Lang.java
+++ b/src/java/main/com/weblyzard/api/model/Lang.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 /** @author Norman Suesstrunk */
 public enum Lang {
-    DE, EN, FR, CS, ES, IT, AF, AR, BG, BN, DA, EL, ET, FA, FI, GU, HE, HI, HR, HU, ID, IS, JA, KN, KO, LT, LV, MK, ML, MR, NE, NL, NO, PA, PL, PT, RO, RU, SK, SL, SO, SQ, SV, SW, TA, TE, TH, TL, TR, UK, UR, VI;
+    ANY, DE, EN, FR, CS, ES, IT, AF, AR, BG, BN, DA, EL, ET, FA, FI, GU, HE, HI, HR, HU, ID, IS, JA, KN, KO, LT, LV, MK, ML, MR, NE, NL, NO, PA, PL, PT, RO, RU, SK, SL, SO, SQ, SV, SW, TA, TE, TH, TL, TR, UK, UR, VI;
 
     /**
      * @param lang

--- a/src/java/main/com/weblyzard/api/model/Lang.java
+++ b/src/java/main/com/weblyzard/api/model/Lang.java
@@ -1,65 +1,21 @@
 package com.weblyzard.api.model;
 
+import java.util.Optional;
+
 /** @author Norman Suesstrunk */
 public enum Lang {
-    DE,
-    EN,
-    FR,
-    CS,
-    ES,
-    IT,
-    AF,
-    AR,
-    BG,
-    BN,
-    DA,
-    EL,
-    ET,
-    FA,
-    FI,
-    GU,
-    HE,
-    HI,
-    HR,
-    HU,
-    ID,
-    JA,
-    KN,
-    KO,
-    LT,
-    LV,
-    MK,
-    ML,
-    MR,
-    NE,
-    NL,
-    NO,
-    PA,
-    PL,
-    PT,
-    RO,
-    RU,
-    SK,
-    SL,
-    SO,
-    SQ,
-    SV,
-    SW,
-    TA,
-    TE,
-    TH,
-    TL,
-    TR,
-    UK,
-    UR,
-    VI;
+    DE, EN, FR, CS, ES, IT, AF, AR, BG, BN, DA, EL, ET, FA, FI, GU, HE, HI, HR, HU, ID, IS, JA, KN, KO, LT, LV, MK, ML, MR, NE, NL, NO, PA, PL, PT, RO, RU, SK, SL, SO, SQ, SV, SW, TA, TE, TH, TL, TR, UK, UR, VI;
 
     /**
      * @param lang
      * @return the Lang constant for the given language string (case insensitive)
      */
-    public static Lang getLanguage(String lang) {
-        return valueOf(lang.toUpperCase());
+    public static Optional<Lang> getLanguage(String lang) {
+        try {
+            return Optional.of(valueOf(lang.toUpperCase()));
+        } catch (NullPointerException | IllegalArgumentException e) {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/src/java/main/com/weblyzard/api/model/document/Document.java
+++ b/src/java/main/com/weblyzard/api/model/document/Document.java
@@ -1,14 +1,8 @@
 package com.weblyzard.api.model.document;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.weblyzard.api.model.annotation.Annotation;
-import com.weblyzard.api.serialize.json.DocumentHeaderDeserializer;
 import java.io.Serializable;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,21 +17,30 @@ import javax.xml.bind.annotation.XmlAnyAttribute;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.namespace.QName;
-import lombok.AccessLevel;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.weblyzard.api.model.Lang;
+import com.weblyzard.api.model.annotation.Annotation;
+import com.weblyzard.api.serialize.json.DocumentHeaderDeserializer;
+import com.weblyzard.api.serialize.xml.LangAdapter;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.experimental.Accessors;
+
 /**
  * The {@link Document} and {@link Sentence} model classes used to represent documents.
  *
- * <p>The {@link Document} class also supports arbitrary meta data which is stored in the <code>
+ * <p>
+ * The {@link Document} class also supports arbitrary meta data which is stored in the <code>
  * header</code> instance variable.
  *
- * <p>The static helper function {@link Document#getXmlRepresentation(Document)} and {@link
- * Document#unmarshallDocumentXmlString(String)} translate between {@link Document} objects and the
- * corresponding XML representations.
+ * <p>
+ * The static helper function {@link Document#toXml(Document)} and
+ * {@link Document#fromXml(String)} translate between {@link Document} objects
+ * and the corresponding XML representations.
  *
  * @author weichselbraun@weblyzard.com
  */
@@ -56,30 +59,6 @@ public class Document implements Serializable {
     /** The Attribute used to encode document keywords */
     public static final QName WL_KEYWORD_ATTR = new QName(NS_DUBLIN_CORE, "subject");
 
-    @JsonDeserialize(keyUsing = DocumentHeaderDeserializer.class)
-    @XmlAnyAttribute
-    private Map<QName, String> header = new HashMap<>();
-
-    @XmlElement(name = "title", namespace = Document.NS_WEBLYZARD)
-    private String title;
-
-    @XmlElement(name = "body")
-    private String body;
-
-    /** attributes required for the annotation handling */
-    @JsonProperty("body_annotation")
-    @XmlElement(name = "body_annotation", namespace = Document.NS_WEBLYZARD)
-    private List<Annotation> bodyAnnotations;
-
-    @JsonProperty("title_annotation")
-    @XmlElement(name = "title_annotation", namespace = Document.NS_WEBLYZARD)
-    private List<Annotation> titleAnnotations;
-
-    /** Elements used in the output (and input) */
-    @JsonProperty("sentences")
-    @XmlElement(name = "sentence", namespace = Document.NS_WEBLYZARD)
-    private List<Sentence> sentences;
-
     @XmlAttribute(name = "id", namespace = Document.NS_WEBLYZARD)
     private String id;
 
@@ -88,47 +67,32 @@ public class Document implements Serializable {
 
     @JsonProperty("lang")
     @XmlAttribute(name = "lang", namespace = javax.xml.XMLConstants.XML_NS_URI)
-    private String lang;
+    @XmlJavaTypeAdapter(LangAdapter.class)
+    private Lang lang;
 
     @XmlAttribute(namespace = Document.NS_WEBLYZARD)
     private String nilsimsa;
+
+    @JsonDeserialize(keyUsing = DocumentHeaderDeserializer.class)
+    @XmlAnyAttribute
+    private Map<QName, String> header = new HashMap<>();
+
+    /** Elements used in the output (and input) */
+    @JsonProperty("sentences")
+    @XmlElement(name = "sentence", namespace = Document.NS_WEBLYZARD)
+    private List<Sentence> sentences;
 
     /**
      * This field contains all annotations after titleAnnotations and bodyAnnotations have been
      * merged. (i.e. after the document's finalization)
      */
-    @Setter(AccessLevel.PROTECTED)
     @JsonProperty("annotations")
     @XmlElement(name = "annotation", namespace = Document.NS_WEBLYZARD)
     private List<Annotation> annotations;
 
-    /** @param body the {@link Document}'s body */
-    public Document(String body) {
-        this.title = "";
-        this.body = body;
-    }
-
-    /**
-     * @param title the {@link Document}'s title
-     * @param body the {@link Document}'s body
-     * @param header a Map of optional meta data to store with the document
-     */
-    public Document(String title, String body, Map<QName, String> header) {
-        this.title = title;
-        this.body = body;
-        this.header = header;
-    }
-
+    @Override
     public Object clone() throws CloneNotSupportedException {
         return super.clone();
-    }
-
-    public List<Annotation> getBodyAnnotations() {
-        return bodyAnnotations != null ? bodyAnnotations : Collections.<Annotation>emptyList();
-    }
-
-    public List<Annotation> getTitleAnnotations() {
-        return titleAnnotations != null ? titleAnnotations : Collections.<Annotation>emptyList();
     }
 
     /**
@@ -138,11 +102,10 @@ public class Document implements Serializable {
      * @return An XML representation of the given {@link Document} object.
      * @throws JAXBException
      */
-    public static String getXmlRepresentation(Document document) throws JAXBException {
+    public static String toXml(Document document) throws JAXBException {
         StringWriter stringWriter = new StringWriter();
-        JAXBElement<Document> jaxbElement =
-                new JAXBElement<>(
-                        new QName(Document.NS_WEBLYZARD, "page", "wl"), Document.class, document);
+        JAXBElement<Document> jaxbElement = new JAXBElement<>(
+                new QName(Document.NS_WEBLYZARD, "page", "wl"), Document.class, document);
         JAXBContext jaxbContext = JAXBContext.newInstance(Document.class);
         Marshaller xmlMarshaller = jaxbContext.createMarshaller();
         xmlMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
@@ -157,7 +120,7 @@ public class Document implements Serializable {
      * @return The {@link Document} instance corresponding to the xmlString
      * @throws JAXBException
      */
-    public static Document unmarshallDocumentXmlString(String xmlString) throws JAXBException {
+    public static Document fromXml(String xmlString) throws JAXBException {
         JAXBContext jaxbContext = JAXBContext.newInstance(Document.class);
         Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
         StringReader reader = new StringReader(xmlString);

--- a/src/java/main/com/weblyzard/api/model/document/MirrorDocument.java
+++ b/src/java/main/com/weblyzard/api/model/document/MirrorDocument.java
@@ -1,0 +1,57 @@
+package com.weblyzard.api.model.document;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.xml.namespace.QName;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.weblyzard.api.model.Lang;
+import com.weblyzard.api.model.annotation.Annotation;
+import com.weblyzard.api.serialize.json.LangDeserializer;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+
+/**
+ * The {@link MirrorDocument} represents a document with separate title and body fields as created
+ * by mirror processes.
+ *
+ * @author weichselbraun@weblyzard.com
+ */
+@Data
+@Accessors(chain = true)
+@NoArgsConstructor
+public class MirrorDocument implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** a unique document identifier such as the content id */
+    private String id;
+    private String title;
+    private String body;
+
+    /** the document's content type (e.g. `text/html`) */
+    private String format;
+    @JsonDeserialize(using = LangDeserializer.class)
+    private Lang lang;
+
+    /** arbitrary header metadata */
+    private Map<QName, String> header;
+
+    /** attributes required for the annotation handling */
+    @JsonProperty("body_annotation")
+    private List<Annotation> bodyAnnotations;
+    @JsonProperty("title_annotation")
+    private List<Annotation> titleAnnotations;
+
+    public List<Annotation> getBodyAnnotations() {
+        return bodyAnnotations != null ? bodyAnnotations : Collections.<Annotation>emptyList();
+    }
+
+    public List<Annotation> getTitleAnnotations() {
+        return titleAnnotations != null ? titleAnnotations : Collections.<Annotation>emptyList();
+    }
+
+}

--- a/src/java/main/com/weblyzard/api/model/document/XmlDocument.java
+++ b/src/java/main/com/weblyzard/api/model/document/XmlDocument.java
@@ -35,6 +35,6 @@ public class XmlDocument {
         contentId = document.getId();
         nilsimsa = document.getNilsimsa();
         this.annotation = annotation;
-        xmlContent = Document.getXmlRepresentation(document);
+        xmlContent = Document.toXml(document);
     }
 }

--- a/src/java/main/com/weblyzard/api/serialize/DocumentInputStreamParser.java
+++ b/src/java/main/com/weblyzard/api/serialize/DocumentInputStreamParser.java
@@ -35,7 +35,7 @@ public class DocumentInputStreamParser {
         List<Document> documentList = new ArrayList<>();
         try (JsonParser jp = jsonFactory.createParser(stream)) {
             jp.nextToken();
-            Document d = Document.unmarshallDocumentXmlString(jp.getValueAsString());
+            Document d = Document.fromXml(jp.getValueAsString());
             if (d != null) {
                 documentList.add(d);
             }
@@ -62,7 +62,7 @@ public class DocumentInputStreamParser {
             // read START_ARRAY
             jp.nextToken();
             while (jp.nextToken() == JsonToken.VALUE_STRING) {
-                Document d = Document.unmarshallDocumentXmlString(jp.getValueAsString());
+                Document d = Document.fromXml(jp.getValueAsString());
                 if (d != null) {
                     documentList.add(d);
                 }

--- a/src/java/main/com/weblyzard/api/serialize/json/LangDeserializer.java
+++ b/src/java/main/com/weblyzard/api/serialize/json/LangDeserializer.java
@@ -1,0 +1,27 @@
+package com.weblyzard.api.serialize.json;
+
+import java.io.IOException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.weblyzard.api.model.Lang;
+
+public class LangDeserializer extends StdDeserializer<Lang> {
+
+    private static final long serialVersionUID = 1L;
+
+    public LangDeserializer() {
+        this(null);
+    }
+
+    protected LangDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public Lang deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        return Lang.getLanguage(p.getValueAsString()).orElse(null);
+    }
+}

--- a/src/java/main/com/weblyzard/api/serialize/xml/LangAdapter.java
+++ b/src/java/main/com/weblyzard/api/serialize/xml/LangAdapter.java
@@ -1,0 +1,23 @@
+package com.weblyzard.api.serialize.xml;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import com.weblyzard.api.model.Lang;
+
+/**
+ * Serialization and deserialization of Lang attributes
+ * 
+ * @author Albert Weichselbraun
+ */
+public class LangAdapter extends XmlAdapter<String, Lang> {
+
+    @Override
+    public String marshal(Lang v) throws Exception {
+        return v.toString();
+    }
+
+    @Override
+    public Lang unmarshal(String v) throws Exception {
+        return Lang.getLanguage(v).orElse(null);
+    }
+
+}

--- a/src/java/test/com/weblyzard/api/client/integration/JeremiaClientIT.java
+++ b/src/java/test/com/weblyzard/api/client/integration/JeremiaClientIT.java
@@ -1,13 +1,14 @@
 package com.weblyzard.api.client.integration;
 
 import static org.junit.Assert.assertNotNull;
-
-import com.weblyzard.api.client.JeremiaClient;
-import com.weblyzard.api.model.document.Document;
 import javax.ws.rs.ClientErrorException;
 import javax.xml.bind.JAXBException;
 import org.junit.Before;
 import org.junit.Test;
+import com.weblyzard.api.client.JeremiaClient;
+import com.weblyzard.api.model.Lang;
+import com.weblyzard.api.model.document.Document;
+import com.weblyzard.api.model.document.MirrorDocument;
 
 public class JeremiaClientIT extends TestClientBase {
 
@@ -20,11 +21,10 @@ public class JeremiaClientIT extends TestClientBase {
 
     @Test
     public void testSubmitDocument() throws ClientErrorException, JAXBException {
-        //assumeTrue(weblyzardServiceAvailable(jeremiaClient));
-        Document request =
-                new Document(
-                        "Fast Track's Karen Bowerman asks what the changes in penguin population could mealenn for the rest of us in the event of climate change.");
-        request.setLang("en");
+        // assumeTrue(weblyzardServiceAvailable(jeremiaClient));
+        MirrorDocument request = new MirrorDocument().setBody(
+                "Fast Track's Karen Bowerman asks what the changes in penguin population could mealenn for the rest of us in the event of climate change.")
+                .setLang(Lang.EN);
         Document response1 = jeremiaClient.submitDocument(request);
         assertNotNull(response1);
     }

--- a/src/java/test/com/weblyzard/api/client/integration/JoelClientIT.java
+++ b/src/java/test/com/weblyzard/api/client/integration/JoelClientIT.java
@@ -5,15 +5,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
-
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.weblyzard.api.client.JoelClient;
-import com.weblyzard.api.model.document.Document;
-import com.weblyzard.api.model.joel.ClusterResult;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -21,6 +12,15 @@ import javax.ws.rs.ClientErrorException;
 import javax.xml.bind.JAXBException;
 import org.junit.Before;
 import org.junit.Test;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.weblyzard.api.client.JoelClient;
+import com.weblyzard.api.model.document.Document;
+import com.weblyzard.api.model.document.Sentence;
+import com.weblyzard.api.model.joel.ClusterResult;
 
 /** @author norman.suesstrunk@htwchur.ch */
 public class JoelClientIT extends TestClientBase {
@@ -59,10 +59,10 @@ public class JoelClientIT extends TestClientBase {
     public void testDocumentHeaderBadRequest() {
         assumeTrue(weblyzardServiceAvailable(joelClient));
         try {
-            joelClient.addDocuments(Arrays.asList(new Document[] {new Document("Test")}));
+            joelClient.addDocuments(Arrays.asList(new Document[] {
+                    new Document().setSentences(Arrays.asList(new Sentence("Test")))}));
         } catch (ClientErrorException clientErrorException) {
-            assertThat(
-                    clientErrorException.getMessage(),
+            assertThat(clientErrorException.getMessage(),
                     is(JoelClient.NO_KEYWORD_IN_DOCUMENT_HEADER_MESSAGE));
         } catch (JAXBException jaxbException) {
             jaxbException.printStackTrace();
@@ -76,8 +76,7 @@ public class JoelClientIT extends TestClientBase {
             ObjectMapper objectMapper = new ObjectMapper();
             objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
             return objectMapper.readValue(
-                    JoelClientIT.class
-                            .getClassLoader()
+                    JoelClientIT.class.getClassLoader()
                             .getResourceAsStream(PSALMS_DOCS_WEBLYZARDFORMAT_JSON),
                     new TypeReference<List<Document>>() {});
         } catch (JsonParseException e1) {

--- a/src/java/test/com/weblyzard/api/client/integration/RecognyzeClientIT.java
+++ b/src/java/test/com/weblyzard/api/client/integration/RecognyzeClientIT.java
@@ -26,10 +26,10 @@ public class RecognyzeClientIT extends TestClientBase {
     private static final String PSALMS_DOCS_WEBLYZARDFORMAT =
             "resources/reference/weblyzard-example.xml";
 
-    private Document loadDocument() throws JAXBException, IOException {
+    private static Document loadDocument() throws JAXBException, IOException {
         File xmlFile = new File(RecognyzeClientIT.class.getClassLoader()
                 .getResource(PSALMS_DOCS_WEBLYZARDFORMAT).getFile());
-        Document document = Document.unmarshallDocumentXmlString(
+        Document document = Document.fromXml(
                 Files.readLines(xmlFile, Charsets.UTF_8).stream().collect(Collectors.joining()));
         return document;
     }

--- a/src/java/test/com/weblyzard/api/document/DocumentJsonTest.java
+++ b/src/java/test/com/weblyzard/api/document/DocumentJsonTest.java
@@ -34,7 +34,7 @@ public class DocumentJsonTest {
 
         // init mock objects
         referenceDocument =
-                Document.unmarshallDocumentXmlString(
+                Document.fromXml(
                         Resources.toString(WEBLYZARD_EXAMPLE_XML, Charsets.UTF_8));
 
         referenceKeywordQName =

--- a/src/java/test/com/weblyzard/api/model/LangTest.java
+++ b/src/java/test/com/weblyzard/api/model/LangTest.java
@@ -1,15 +1,24 @@
 package com.weblyzard.api.model;
 
-import static org.junit.Assert.*;
-
+import static org.junit.Assert.assertEquals;
+import java.util.Optional;
 import org.junit.Test;
 
 public class LangTest {
 
     @Test
     public void test() {
-        Lang l = Lang.getLanguage("de");
+        Lang l = Lang.getLanguage("de").get();
         assertEquals(Lang.DE, l);
         assertEquals("de", l.toString());
+    }
+
+    @Test
+    public void testIllegalLanguages() {
+        // null pointer language
+        assertEquals(Optional.empty(), Lang.getLanguage(null));
+
+        // non existent language
+        assertEquals(Optional.empty(), Lang.getLanguage("invalid"));
     }
 }

--- a/src/java/test/com/weblyzard/api/serialize/xml/SerializationTest.java
+++ b/src/java/test/com/weblyzard/api/serialize/xml/SerializationTest.java
@@ -1,0 +1,39 @@
+package com.weblyzard.api.serialize.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.io.IOException;
+import java.util.Arrays;
+import javax.xml.bind.JAXBException;
+import org.junit.Test;
+import com.weblyzard.api.model.Lang;
+import com.weblyzard.api.model.document.Document;
+import com.weblyzard.api.model.document.Sentence;
+
+public class SerializationTest {
+
+    @Test
+    public void test() throws IOException, JAXBException {
+        final Sentence sentence = new Sentence(
+                "McChain (former US presidente candidate) stated that he would strongly support such actions.",
+                "0,7 8,9 9,15 16,18 19,29 30,39 39,40 41,47 48,52 53,55 56,61 62,70 71,78 79,83 84,91 91,92",
+                "NNP ( JJ NNP NN NN ) VBD IN PRP MD RB VB JJ NNS .");
+
+        final Document document = new Document().setId("12").setSentences(Arrays.asList(sentence));
+
+        // test document
+        testSerialization(document);
+
+        // language
+        document.setLang(Lang.EN);
+        testSerialization(document);
+
+        // ensure that the value used for lang is lowercase
+        assertTrue(Document.toXml(document).contains("lang=\"en\""));
+    }
+
+    private static void testSerialization(Document document) throws IOException, JAXBException {
+        String xmlString = Document.toXml(document);
+        assertEquals(document, Document.fromXml(xmlString));
+    }
+}


### PR DESCRIPTION
This merge yields the following changes that are _only_ relevant to the java projects (i.e. do not change the API towards python).

 1. use the Lang enum rather than String in all model classes to represent languages
 2. introduction of the `MirrorDocument` class used for input documents that contain title and body rather than a list of sentences (i.e. the documents send to Jeremia).
 3. remove `title`, `body` and the corresponding annotation types from the `Document` class.

These changes make using the model classes more intuitive and less error-prone, since calling methods such as `finalizeDocument` is not longer necessary.