### PR TITLE
fix: update to jackson-databind 2.9.7 to fix a servere security issue.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.weblyzard.api</groupId>
 	<artifactId>weblyzard-api</artifactId>
-	<version>0.2.1.0-SNAPSHOT</version>
+	<version>0.2.1.2-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>com.weblyzard.api.weblyzard-api</name>
@@ -250,7 +250,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.8.9</version>
+			<version>2.9.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>


### PR DESCRIPTION
please refer to https://github.com/weblyzard/weblyzard_api/network/alert/pom.xml/com.fasterxml.jackson.core:jackson-databind/open for more information.