### PR TITLE
fix: wrong path for entity batch specified

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools.command import sdist
 
 setup(
     name='weblyzard_api',
-    version='0.7.20181217-dev',
+    version='0.7.20190207-dev',
     description=' Web services for weblyzard',
     author='Albert Weichselbraun, Heinz-Peter Lang, Max Göbel and Philipp Kuntschik',
     author_email='weichselbraun@weblyzard.com',

--- a/src/python/weblyzard_api/client/skb_rest_client.py
+++ b/src/python/weblyzard_api/client/skb_rest_client.py
@@ -155,7 +155,7 @@ class SKBRESTClient(object):
             assert 'entityType' in entity
         if len(entity_list) < 1:
             return None
-        urlpath = self.ENTITY_PATH
+        urlpath = self.ENTITY_BATCH_PATH
         if force_update:
             urlpath = u'{}?force_update'.format(urlpath)
         response = requests.post('{}/{}'.format(self.url,


### PR DESCRIPTION
made a grave mistake here, unfortunately: the batches are now sent to the endpoint only accepting single 